### PR TITLE
Bug fix: fragment block should include fragment classnames

### DIFF
--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -46,12 +46,13 @@ export default async function decorate(block) {
   const path = link ? link.getAttribute('href') : block.textContent.trim();
   const fragment = await loadFragment(path);
   if (fragment) {
-    const fragmentSection = fragment.querySelector(':scope .section');
-    if (fragmentSection) {
-      block.closest('.section').classList.add(...fragmentSection.classList);
-      const clonedBlockDiv = block.closest('.fragment').cloneNode(false);
-      clonedBlockDiv.append(...fragmentSection.childNodes);
-      block.closest('.fragment').replaceWith(clonedBlockDiv);
+    const fragmentSections = fragment.querySelectorAll(':scope .section');
+    if (fragmentSections.length > 0) {
+      const blockDiv = block.closest('.fragment');
+      blockDiv.innerHTML = '';
+      fragmentSections.forEach((section) => {
+        blockDiv.appendChild(section);
+      });
     }
   }
 }

--- a/blocks/fragment/fragment.js
+++ b/blocks/fragment/fragment.js
@@ -49,7 +49,9 @@ export default async function decorate(block) {
     const fragmentSection = fragment.querySelector(':scope .section');
     if (fragmentSection) {
       block.closest('.section').classList.add(...fragmentSection.classList);
-      block.closest('.fragment').replaceWith(...fragment.childNodes);
+      const clonedBlockDiv = block.closest('.fragment').cloneNode(false);
+      clonedBlockDiv.append(...fragmentSection.childNodes);
+      block.closest('.fragment').replaceWith(clonedBlockDiv);
     }
   }
 }


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fixes:
- HTML DOM to include fragment block along with its classnames.
- Include all fragment sections under fragment block.(currently only first one is being rendered)

Test URLs:
- Before: https://main--com--ancestry.aem.live/en/
- After: https://fragment-block-fix--com--ancestry.aem.live/en/
