### PR TITLE
update: [homepage] Hero banner update

### DIFF
--- a/blocks/banner/banner.css
+++ b/blocks/banner/banner.css
@@ -216,6 +216,10 @@
     text-decoration: underline;
   }
 
+  .banner.image .anchor:hover {
+    background-color: transparent;
+  }
+  
   .banner.no-image > div {
     margin: 0 2rem;
   }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -19,7 +19,7 @@
   display: block;
 }
 
-@media (width >= 900px) {
+/* @media (width >= 900px) {
   .columns > div {
     align-items: center;
     flex-direction: unset;
@@ -30,7 +30,7 @@
     flex: 1;
     order: unset;
   }
-}
+} */
 
 /* Homepage */
 
@@ -301,5 +301,59 @@ main .section.columns-container > div{
 
   .columns.homepage.block.columns-2-cols > div > .text-content p {
     font-size: 1.15rem;
+  }
+}
+
+/* Columns with 3 columns */
+.columns.footer.block.columns-3-cols {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  max-width: 800px;
+  margin: 0 auto;
+  padding: 1rem;
+  font-size: 0.9rem;
+  color: var(--text-gray-dark-color);
+  position: relative;
+}
+
+.columns.footer.block.columns-3-cols::before {
+  content: none;
+}
+
+.columns.footer.block.columns-3-cols .bg-color-1 {
+  display: flex;
+  flex-direction: row;
+  justify-content: center;
+  align-items: flex-start;
+  gap: 4em;
+  width: 100%;
+}
+
+.columns.footer.block.columns-3-cols .text-content p {
+  margin: 0;
+}
+
+
+.columns.footer.block.columns-3-cols > div {
+  align-items:flex-start;
+  gap:2.5rem;
+}
+
+@media (max-width: 750px) {
+  .columns.footer.block.columns-3-cols .bg-color-1 {
+    flex-direction: column;
+    align-items: center;
+    gap: 0.5rem;
+  }
+
+  .columns.footer.block.columns-3-cols .text-content p {
+    padding: 0;
+  }
+
+  .columns.footer.block.columns-3-cols .bg-color-1 .text-content {
+    max-width: 100%;
+    margin-bottom: 20px; 
+    text-align: center;
   }
 }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -19,19 +19,6 @@
   display: block;
 }
 
-/* @media (width >= 900px) {
-  .columns > div {
-    align-items: center;
-    flex-direction: unset;
-    gap: 24px;
-  }
-
-  .columns > div > div {
-    flex: 1;
-    order: unset;
-  }
-} */
-
 /* Homepage */
 
 /* Clear the padding and margin at homepage */
@@ -154,9 +141,17 @@ main .section.columns-container > div{
   width: 100vw;
 }
 
-/* Blue background with blue button */
-.columns.homepage.block.columns-2-cols .bg-color-3 .button{
+/* DNA button with blue background */
+.columns.homepage.block.columns-2-cols .dna-button{
  background-color: var(--button-blue-color);
+}
+
+.columns.homepage.block.columns-2-cols .dna-button:hover {
+  background-color: var(--button-blue-hover-color);
+}
+
+.columns.homepage.block.columns-2-cols .dna-button:active {
+  background-color: var(--button-blue-active-color);
 }
 
 /* Mobile-specific adjustments */
@@ -205,7 +200,7 @@ main .section.columns-container > div{
   }
 }
 
-/* Tablet and Desktop Styles (768px and above) */
+/* Tablet and Desktop Styles */
 @media (min-width: 900px) {
   .columns.homepage.block.columns-2-cols > div {
     display: flex;
@@ -356,19 +351,19 @@ main .section.columns-container > div{
 }
 
 @media (max-width: 750px) {
-  .columns.footer.block.columns-3-cols .bg-color-1 {
+  .columns.footer.block.columns-3-cols > div {
     flex-direction: column;
     align-items: center;
     gap: 0.5rem;
   }
 
-  .columns.footer.block.columns-3-cols .text-content p {
-    padding: 0;
-  }
-
-  .columns.footer.block.columns-3-cols .bg-color-1 .text-content {
+  .columns.footer.block.columns-3-cols .text-content {
     max-width: 100%;
     margin-bottom: 20px; 
     text-align: center;
+  }
+
+  .columns.footer.block.columns-3-cols .text-content p {
+    padding: 0;
   }
 }

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -304,7 +304,7 @@ main .section.columns-container > div{
   }
 }
 
-/* Columns with 3 columns */
+/* Columns between cards and footer at homepage */
 .columns.footer.block.columns-3-cols {
   display: flex;
   flex-direction: column;
@@ -321,23 +321,38 @@ main .section.columns-container > div{
   content: none;
 }
 
-.columns.footer.block.columns-3-cols .bg-color-1 {
+.columns.footer.block.columns-3-cols .text-content p {
+  margin: 0;
+}
+
+.columns.footer.block.columns-3-cols .button-container .button {
+  background-color: transparent;
+  border: none;
+  padding: 0;
+  margin: 0;
+  color: #36322d;
+  font: inherit;
+  text-align: left;
+  display: inline;
+  -webkit-font-smoothing: antialiased;
+}
+
+.columns.footer.block.columns-3-cols .button:hover,
+.columns.footer.block.columns-3-cols .button:active,
+.columns.footer.block.columns-3-cols .button:focus {
+  background-color: transparent;
+  color: var(--button-blue-active-color);
+  text-decoration: underline;
+  outline: none; 
+}
+
+.columns.footer.block.columns-3-cols > div {
   display: flex;
   flex-direction: row;
   justify-content: center;
   align-items: flex-start;
   gap: 4em;
   width: 100%;
-}
-
-.columns.footer.block.columns-3-cols .text-content p {
-  margin: 0;
-}
-
-
-.columns.footer.block.columns-3-cols > div {
-  align-items:flex-start;
-  gap:2.5rem;
 }
 
 @media (max-width: 750px) {

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -20,8 +20,8 @@ function wrapAncestryText(element) {
 }
 
 // Check for DNA icon and apply blue button background
-function checkDNAIconAndApplyClass() {
-  const dnaIcons = document.querySelectorAll('img[data-icon-name="icon-dna"]');
+function checkDNAIconAndApplyClass(block) {
+  const dnaIcons = block.querySelectorAll('img[data-icon-name="icon-dna"]');
 
   dnaIcons.forEach((dnaIcon) => {
     const container = dnaIcon.closest('.bg-color-1, .bg-color-2, .bg-color-3');
@@ -68,5 +68,5 @@ export default function decorate(block) {
       wrapAncestryText(textContent);
     }
   });
-  checkDNAIconAndApplyClass();
+  checkDNAIconAndApplyClass(block);
 }

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -19,6 +19,20 @@ function wrapAncestryText(element) {
   traverseNodes(element);
 }
 
+// Check for DNA icon and apply blue button background
+function checkDNAIconAndApplyClass() {
+  const dnaIcons = document.querySelectorAll('img[data-icon-name="icon-dna"]');
+
+  dnaIcons.forEach((dnaIcon) => {
+    const container = dnaIcon.closest('.bg-color-1, .bg-color-2, .bg-color-3');
+    const button = container.querySelector('.button');
+
+    if (button) {
+      button.classList.add('dna-button');
+    }
+  });
+}
+
 export default function decorate(block) {
   const cols = [...block.firstElementChild.children];
   block.classList.add(`columns-${cols.length}-cols`);
@@ -54,4 +68,5 @@ export default function decorate(block) {
       wrapAncestryText(textContent);
     }
   });
+  checkDNAIconAndApplyClass();
 }

--- a/blocks/fragment/fragment.css
+++ b/blocks/fragment/fragment.css
@@ -1,16 +1,16 @@
 /* Homepage footer fragment */
-main .section.fragment-container.columns-container {
+main .section.fragment-container.cards-container {
     padding-bottom:0;
   }
 
-main .section.fragment-container.columns-container .fragment-wrapper{
+main .section.fragment-container.cards-container .fragment-wrapper{
     margin-bottom: 0;
     margin-top: 6.5rem;
     padding: 0.5rem;
     position: relative;
   }
   
- main .section.fragment-container.columns-container .fragment-wrapper::before {
+ main .section.fragment-container.cards-container .fragment-wrapper::before {
     content: '';
     position: absolute;
     top: 0;
@@ -23,7 +23,7 @@ main .section.fragment-container.columns-container .fragment-wrapper{
   }
 
   @media(max-width: 899px){
-    main .section.fragment-container.columns-container .fragment-wrapper{
+    main .section.fragment-container.cards-container .fragment-wrapper{
       margin-top: 2rem;
     }
   }

--- a/blocks/fragment/fragment.css
+++ b/blocks/fragment/fragment.css
@@ -1,1 +1,30 @@
-/* stylelint-disable no-empty-source */
+/* Homepage footer fragment */
+main .section.fragment-container.columns-container {
+    padding-bottom:0;
+  }
+
+main .section.fragment-container.columns-container .fragment-wrapper{
+    margin-bottom: 0;
+    margin-top: 6.5rem;
+    padding: 0.5rem;
+    position: relative;
+  }
+  
+ main .section.fragment-container.columns-container .fragment-wrapper::before {
+    content: '';
+    position: absolute;
+    top: 0;
+    left: 50%;
+    transform: translateX(-50%);
+    width: 100vw;
+    height: 100%;
+    background-color: #f0eee9;
+    z-index: 0;
+  }
+
+  @media(max-width: 899px){
+    main .section.fragment-container.columns-container .fragment-wrapper{
+      margin-top: 2rem;
+    }
+  }
+  

--- a/blocks/hero-banner/hero-banner.css
+++ b/blocks/hero-banner/hero-banner.css
@@ -1,11 +1,14 @@
 /* General Styles for All Banners */
 main .section.hero-banner-container {
-    height: 600px;
     display: flex;
     flex-direction: column;
     background: var(--hero-banner-background-color);
     overflow: hidden;
     margin:0;
+}
+
+.hero-banner-container > div{
+    max-width:1400px;
 }
 
 .hero-banner-wrapper {
@@ -142,10 +145,6 @@ main .section.hero-banner-container {
 
 /* Mobile: Up to 767px */
 @media (max-width: 600px) {
-    main .section.hero-banner-container {
-        height: 500px;
-    }
-
     .hero-banner-wrapper.mobile-banner-wrapper {
         margin-top: 0;
         display: block;
@@ -187,7 +186,7 @@ main .section.hero-banner-container {
 /* Tablet: 768px to 1005px */
 @media (min-width: 601px) and (max-width: 900px) {
     main .section.hero-banner-container {
-        height: 600px;
+        height: 700px;
     }
 
     .hero-banner {
@@ -195,7 +194,7 @@ main .section.hero-banner-container {
     }
 
     .hero-banner.tab-banner > div > div:first-child {
-        width: 300px;
+        width: 480px;
     }
 
     .hero-banner p:last-of-type {
@@ -210,6 +209,10 @@ main .section.hero-banner-container {
 
 /* Desktop: 1006px and Above */
 @media (min-width: 901px) {
+    .section.hero-banner-container {
+        height: 700px;
+    }
+
     .desktop-banner-wrapper {
         display: block;
         overflow: hidden;
@@ -227,18 +230,19 @@ main .section.hero-banner-container {
     }
 
     .hero-banner.desktop-banner > div > div:first-child {
-        width: 300px;
-        margin: 8rem;
+        width: 480px;
+        padding-left:2rem;
+        margin: 4rem;
     }
 
     .hero-banner.desktop-banner > div > div:last-child {
-        width: 600px;
+        width: 770px;
         flex-shrink: 0;
     }
 
     .hero-banner.desktop-banner img {
-        width: 600px;
-        height: 100%;
+        width: 100%;
+        height: 700px;
         object-fit: cover;
     }
 }


### PR DESCRIPTION
# Update hero banner
Test URLs:
- Before: https://main--com--ancestry.aem.live/
- After: https://hero-banner-update--com--ancestry.aem.page/drafts/xfeng/homepage-2

**Update:**
1. style fix 
2. Support adding ® symbols in the text
3. Support break h1 into different lines with proper margin.

**Example:**
The h1 separated into three lines
<img width="638" alt="Screenshot 2024-10-01 at 3 45 55 PM" src="https://github.com/user-attachments/assets/74ad53c9-8180-40bf-a816-b4514d0c862f">
Display:
<img width="931" alt="Screenshot 2024-10-01 at 3 45 44 PM" src="https://github.com/user-attachments/assets/4be9bc19-68f5-464b-9c12-a92e570e3b0b">

h1 didn't separate but with automatic wrap
<img width="630" alt="Screenshot 2024-10-01 at 3 46 16 PM" src="https://github.com/user-attachments/assets/1eeab808-8c35-41ee-a441-1122a08857bf">
Display:
<img width="931" alt="Screenshot 2024-10-01 at 3 46 12 PM" src="https://github.com/user-attachments/assets/d03787c1-25af-44d6-992c-e600b8100735">
