### PR TITLE
update: [homepage] hero-banner

### DIFF
--- a/blocks/hero-banner/hero-banner.css
+++ b/blocks/hero-banner/hero-banner.css
@@ -1,6 +1,5 @@
 /* General Styles for All Banners */
 main .section.hero-banner-container {
-    height: 600px;
     display: flex;
     flex-direction: column;
     background: var(--hero-banner-background-color);
@@ -9,77 +8,23 @@ main .section.hero-banner-container {
 }
 
 .hero-banner-wrapper {
-    display: none; /* Hide all banners by default */
+    display: none;
 }
 
 .hero-banner {
     color: var(--text-h1-color);
-
-    /* font-family: ui-serif, "Times New Roman", Times, serif; */
     font-size: 0.8rem;
     letter-spacing: 0.03em;
     line-height: 1.33;
 }
 
-.hero-banner img {
-    width: 100%;
-    height: 100%;
-    object-fit: cover;
-}
-
 .hero-banner > div {
     display: flex;
-    flex-direction: column; /* Default direction */
+    flex-direction: column;
     justify-content: center;
     max-width: none;
     height: 100%;
     flex-grow: 1;
-}
-
-.hero-banner .icon::before{
-    font-family:ancestry-icon, sans-serif;
-    content: "\e685";
-    color:#9BBE3C;
-    font-size:2.5rem;
-    text-align:center;
-    font-weight:400;
-}
-
-/* Specific Banner Styles */
-
-/* Mobile Banner Styles */
-.hero-banner.mobile-banner > div {
-    flex-direction: column-reverse;
-}
-
-.hero-banner.mobile-banner img {
-    width: 100%;
-    height: auto;
-    object-fit: cover;
-}
-
-/* Tablet Banner Styles */
-.hero-banner.tab-banner > div {
-    align-items: center;
-    flex-direction: column;
-}
-
-.hero-banner.tab-banner img {
-    width: 100%;
-    height: auto;
-    object-fit: cover;
-}
-
-/* Desktop Banner Styles */
-.hero-banner.desktop-banner > div {
-    display: grid;
-    grid-template-columns: 6fr 4fr;
-    align-items: center;
-}
-
-.hero-banner.desktop-banner img {
-    width: 100%;
-    height: auto;
 }
 
 .hero-banner > div > div:first-child {
@@ -90,24 +35,48 @@ main .section.hero-banner-container {
     text-align: center;
 }
 
-.hero-banner a {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    font-weight: normal;
-}
-
 .hero-banner h1 {
     color: var(--text-h1-color);
     font-family: ui-serif, "Times New Roman", Times, serif;
     font-size: 2rem;
     font-weight: 400;
-    line-height: 1.1;
+    line-height: 1.2;
     letter-spacing: 0.03em;
-    margin-top: 1rem;
+}
+
+/* General margins for when there's only one h1 */
+.hero-banner h1:only-of-type {
+    margin-top: 2rem;
+    margin-bottom: 1.5rem;
+}
+
+/* Apply to h1s that are neither first nor last, when there's more than one h1 */
+.hero-banner h1:not(:first-of-type, :last-of-type) {
+    margin: 0;
+}
+
+/* Apply to the first h1 only when there is more than one h1 */
+.hero-banner h1:first-of-type:not(:only-of-type) {
+    margin-top: 1.5rem;
+    margin-bottom: 0;
+}
+
+/* Apply to the last h1 only when there is more than one h1 */
+.hero-banner h1:last-of-type:not(:only-of-type) {
+    margin-bottom: 2rem;
+    margin-top: 0;
 }
 
 /* Icon Styles */
+.hero-banner .icon::before{
+    font-family:ancestry-icon, sans-serif;
+    content: "\e685";
+    color:#9BBE3C;
+    font-size:2.5rem;
+    text-align:center;
+    font-weight:400;
+}
+
 .hero-banner .icon.icon-icon-acom {
     display: flex;
     justify-content: center;
@@ -123,6 +92,13 @@ main .section.hero-banner-container {
 }
 
 /* Button Styles */
+.hero-banner a {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-weight: normal;
+}
+
 .hero-banner a.button {
     padding: 0.7em 1.5em;
     font-size: 1rem;
@@ -140,62 +116,108 @@ main .section.hero-banner-container {
 
 /* Responsive Styles */
 
-/* Mobile: Up to 767px */
+/* Mobile */
 @media (max-width: 600px) {
-    main .section.hero-banner-container {
-        height: 500px;
-    }
-
     .hero-banner-wrapper.mobile-banner-wrapper {
         margin-top: 0;
         display: block;
     }
 
-    /* Hide Icon on Mobile */
-    .hero-banner .icon.icon-icon-acom img {
-        display: none;
+    .hero-banner.mobile-banner > div {
+        flex-direction: column-reverse;
+        align-items: center;
+        width: 100%;
     }
 
-    .hero-banner .icon::before{
-        display: none;
+    .hero-banner.mobile-banner > div > div {
+        margin: 0 0.5rem;
+    }
+
+    .hero-banner.mobile-banner img {
+        width: 100%;
+        height: auto;
+        object-fit: cover;
+        object-position: center;
+        display: block;
+    }
+
+    /* Hide Icon on Mobile */
+    .hero-banner .icon,
+    .hero-banner .icon::before,
+    .hero-banner .icon.icon-icon-acom img {
+        display: none !important;
+    }
+
+    /* Adjust Text Styles */
+    .hero-banner h1 {
+        font-size: 2rem;
+        font-weight:400;
+        margin: 0;
+        width: 100%;
+        max-width: 480px;
+    }
+
+    /* General margins for when there's only one h1 */
+    .hero-banner h1:only-of-type {
+        margin-top: 1.5rem;
+        margin-bottom: 1rem;
     }
     
-    .hero-banner a.button {
-        padding: 0.6em 1.5em;
-        font-size: 0.9rem;
+    .hero-banner h1:last-of-type:not(:only-of-type) {
+        margin-bottom: 1rem;
     }
 
     .hero-banner p {
         font-size: 0.9em;
         letter-spacing: 0.05em;
+        width: 100%;
+        max-width: 360px;
+        margin: 0.5rem auto;
     }
 
-    .hero-banner h1 {
-        margin: 0;
+    .hero-banner a.button {
+        padding: 0.6em 1.5em;
+        font-size: 0.9rem;
     }
 
     .hero-banner p:last-of-type {
         font-size: 0.8em;
         margin-bottom: 2rem;
     }
-
-    .hero-banner > div {
-        flex-direction: column;
-    }
 }
 
-/* Tablet: 768px to 1005px */
+/* Tablet */
 @media (min-width: 601px) and (max-width: 900px) {
     main .section.hero-banner-container {
-        height: 600px;
+        height: 700px;
     }
 
-    .hero-banner {
-        padding-top: 3rem;
+    .hero-banner.tab-banner > div {
+        display: flex;
+        align-items: center;
+        width: 100%;
+        padding-top:2rem;
     }
 
     .hero-banner.tab-banner > div > div:first-child {
-        width: 300px;
+        width: 100%;
+        max-width: 500px;
+        margin: 0 auto;
+    }
+
+    .hero-banner.tab-banner > div > div:last-child {
+        flex-grow: 1;
+        position: relative;
+        overflow: hidden;
+        height: 100%;
+    }
+
+    .hero-banner.tab-banner img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
+        object-position: center;
+        display: block;
     }
 
     .hero-banner p:last-of-type {
@@ -208,8 +230,13 @@ main .section.hero-banner-container {
     }
 }
 
-/* Desktop: 1006px and Above */
+
+/* Desktop */
 @media (min-width: 901px) {
+    .section.hero-banner-container {
+        height: 700px;
+    }
+
     .desktop-banner-wrapper {
         display: block;
         overflow: hidden;
@@ -217,7 +244,6 @@ main .section.hero-banner-container {
 
     .hero-banner.desktop-banner {
         width: 100%;
-        overflow: hidden;
     }
 
     .hero-banner.desktop-banner > div {
@@ -227,18 +253,23 @@ main .section.hero-banner-container {
     }
 
     .hero-banner.desktop-banner > div > div:first-child {
-        width: 300px;
-        margin: 8rem;
+        width: 490px;
+        padding:2rem;
+        margin: 2rem;
+    }
+    
+    .hero-banner.desktop-banner > div > div p {
+        width: 360px;
     }
 
     .hero-banner.desktop-banner > div > div:last-child {
-        width: 600px;
-        flex-shrink: 0;
+        width: 700px;
     }
 
     .hero-banner.desktop-banner img {
-        width: 600px;
+        width: 100%;
         height: 100%;
         object-fit: cover;
+        object-position: center;
     }
 }

--- a/blocks/hero-banner/hero-banner.css
+++ b/blocks/hero-banner/hero-banner.css
@@ -37,7 +37,6 @@ main .section.hero-banner-container {
 
 .hero-banner h1 {
     color: var(--text-h1-color);
-    font-family: ui-serif, "Times New Roman", Times, serif;
     font-size: 2rem;
     font-weight: 400;
     line-height: 1.2;
@@ -118,27 +117,44 @@ main .section.hero-banner-container {
 
 /* Mobile */
 @media (max-width: 600px) {
-    .hero-banner-wrapper.mobile-banner-wrapper {
-        margin-top: 0;
-        display: block;
+/* Image Wrapper Styles */
+    .hero-banner .image-wrapper {
+        width: 100%;
+        height: 200px;
+        max-width: 350px;
+        margin: 0 auto;
+        overflow: hidden;
+        display: flex;
+        justify-content: center;
+        align-items: center;
+        flex-shrink: 0;
+    }
+
+    .hero-banner .image-wrapper::before {
+        display: none;
+    }
+
+    .hero-banner .image-wrapper img {
+        width: 100%;
+        height: 100%;
+        object-fit: cover;
     }
 
     .hero-banner.mobile-banner > div {
+        display: flex;
         flex-direction: column-reverse;
         align-items: center;
         width: 100%;
     }
 
-    .hero-banner.mobile-banner > div > div {
-        margin: 0 0.5rem;
+    .hero-banner-wrapper.mobile-banner-wrapper {
+        margin-top: 0;
+        display: block;
     }
 
-    .hero-banner.mobile-banner img {
+    .hero-banner.mobile-banner > div > div {
+        margin: 0 0.5rem;
         width: 100%;
-        height: auto;
-        object-fit: cover;
-        object-position: center;
-        display: block;
     }
 
     /* Hide Icon on Mobile */
@@ -155,6 +171,7 @@ main .section.hero-banner-container {
         margin: 0;
         width: 100%;
         max-width: 480px;
+        min-height:120px;
     }
 
     /* General margins for when there's only one h1 */

--- a/blocks/hero-banner/hero-banner.js
+++ b/blocks/hero-banner/hero-banner.js
@@ -55,7 +55,7 @@ function setImageDimensions() {
         if (width && height) {
           const aspectRatio = (height / width).toFixed(4);
 
-          // Only set aspect ratio if not on mobile
+          // Set aspect ratio if not on mobile
           if (window.innerWidth > 600) {
             wrapper.style.setProperty('--aspect-ratio', aspectRatio);
           }
@@ -78,7 +78,6 @@ export default function decorate() {
     const heroBanner = wrapper.querySelector('.hero-banner');
 
     if (heroBanner) {
-      // Check the class of the inner div and apply the corresponding class to the outer wrapper
       if (heroBanner.classList.contains('mobile-banner')) {
         wrapper.classList.add('mobile-banner-wrapper');
       } else if (heroBanner.classList.contains('tab-banner')) {
@@ -87,11 +86,10 @@ export default function decorate() {
         wrapper.classList.add('desktop-banner-wrapper');
       }
 
-      wrapAncestryText(heroBanner); // Your existing function
+      wrapAncestryText(heroBanner);
     }
   });
 
-  // Call the new functions after the DOM is manipulated
   wrapImagesInContainer();
   setImageDimensions();
 }

--- a/blocks/hero-banner/hero-banner.js
+++ b/blocks/hero-banner/hero-banner.js
@@ -1,7 +1,30 @@
-export default function decorate(block) {
-  const ctaContainer = block.querySelector('.button-container');
-  const ctaLink = ctaContainer.querySelector('a');
+// Wrap 'Ancestry' in a span with class 'ancestry' within a given element
+function wrapAncestryText(element) {
+  const ancestryRegex = /AncestryDNA|Ancestry/g;
+  function traverseNodes(node) {
+    node.childNodes.forEach((child) => {
+      if (child.nodeType === Node.TEXT_NODE) {
+        const updatedText = child.textContent.replace(ancestryRegex, (match) => {
+          if (child.parentElement && child.parentElement.classList.contains('ancestry')) {
+            return match;
+          }
+          return `<span class="ancestry">${match}</span>`;
+        });
+        if (updatedText !== child.textContent) {
+          const wrapper = document.createElement('span');
+          wrapper.innerHTML = updatedText;
+          child.replaceWith(...wrapper.childNodes);
+        }
+      } else if (child.nodeType === Node.ELEMENT_NODE && child.nodeName !== 'SCRIPT' && child.nodeName !== 'STYLE') {
+        traverseNodes(child);
+      }
+    });
+  }
 
+  traverseNodes(element);
+}
+
+export default function decorate() {
   const heroBannerWrappers = document.querySelectorAll('.hero-banner-wrapper');
 
   heroBannerWrappers.forEach((wrapper) => {
@@ -16,17 +39,8 @@ export default function decorate(block) {
       } else if (heroBanner.classList.contains('desktop-banner')) {
         wrapper.classList.add('desktop-banner-wrapper');
       }
+
+      wrapAncestryText(heroBanner);
     }
   });
-
-  // Look for Ancestry word in ctaLink and wrap it in a span
-  if (ctaLink) {
-    const ancestryRegex = /Ancestry/;
-    const ctaText = ctaLink.innerHTML;
-
-    if (ancestryRegex.test(ctaText)) {
-      const updatedText = ctaText.replace(ancestryRegex, '<span class="ancestry">Ancestry</span>');
-      ctaLink.innerHTML = updatedText;
-    }
-  }
 }

--- a/blocks/hero-banner/hero-banner.js
+++ b/blocks/hero-banner/hero-banner.js
@@ -24,6 +24,53 @@ function wrapAncestryText(element) {
   traverseNodes(element);
 }
 
+function wrapImagesInContainer() {
+  const heroBannerWrappers = document.querySelectorAll('.hero-banner-wrapper');
+
+  heroBannerWrappers.forEach((wrapper) => {
+    const pictures = wrapper.querySelectorAll('picture');
+
+    pictures.forEach((picture) => {
+      if (!picture.parentElement.classList.contains('image-wrapper')) {
+        const wrapperDiv = document.createElement('div');
+        wrapperDiv.classList.add('image-wrapper');
+        picture.parentNode.insertBefore(wrapperDiv, picture);
+        wrapperDiv.appendChild(picture);
+      }
+    });
+  });
+}
+
+function setImageDimensions() {
+  const imageWrappers = document.querySelectorAll('.image-wrapper');
+
+  imageWrappers.forEach((wrapper) => {
+    const img = wrapper.querySelector('img');
+
+    if (img) {
+      const setAspectRatio = () => {
+        const width = img.naturalWidth;
+        const height = img.naturalHeight;
+
+        if (width && height) {
+          const aspectRatio = (height / width).toFixed(4);
+
+          // Only set aspect ratio if not on mobile
+          if (window.innerWidth > 600) {
+            wrapper.style.setProperty('--aspect-ratio', aspectRatio);
+          }
+        }
+      };
+
+      if (img.complete) {
+        setAspectRatio();
+      } else {
+        img.onload = setAspectRatio;
+      }
+    }
+  });
+}
+
 export default function decorate() {
   const heroBannerWrappers = document.querySelectorAll('.hero-banner-wrapper');
 
@@ -40,7 +87,11 @@ export default function decorate() {
         wrapper.classList.add('desktop-banner-wrapper');
       }
 
-      wrapAncestryText(heroBanner);
+      wrapAncestryText(heroBanner); // Your existing function
     }
   });
+
+  // Call the new functions after the DOM is manipulated
+  wrapImagesInContainer();
+  setImageDimensions();
 }


### PR DESCRIPTION
# Update hero banner
Test URLs:
- Before: https://main--com--ancestry.aem.live/
- After: https://update-hero-banner--com--ancestry.aem.page/drafts/xfeng/homepage-2

**Update:**
1. style fix 
2. Support adding ® symbols in the text
3. Support break h1 into different lines with proper margin.

**Example:**
The h1 separated into three lines
<img width="638" alt="Screenshot 2024-10-01 at 3 45 55 PM" src="https://github.com/user-attachments/assets/74ad53c9-8180-40bf-a816-b4514d0c862f">
Display:
<img width="931" alt="Screenshot 2024-10-01 at 3 45 44 PM" src="https://github.com/user-attachments/assets/4be9bc19-68f5-464b-9c12-a92e570e3b0b">

h1 didn't separate but with automatic wrap
<img width="630" alt="Screenshot 2024-10-01 at 3 46 16 PM" src="https://github.com/user-attachments/assets/1eeab808-8c35-41ee-a441-1122a08857bf">
Display:
<img width="931" alt="Screenshot 2024-10-01 at 3 46 12 PM" src="https://github.com/user-attachments/assets/d03787c1-25af-44d6-992c-e600b8100735">

