### PR TITLE
update: [homepage] re-authoring columns block

### DIFF
--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -46,6 +46,11 @@ main .section.columns-container > div{
   margin-bottom: 0;
 }
 
+.columns .text-content .trademark {
+  font-size: 0.4em;
+  position: relative;
+}
+
 /* Last h2 in .text-content: margin-bottom only, no margin-top */
 .text-content h2:last-of-type {
   margin-bottom: 1rem;
@@ -62,14 +67,6 @@ main .section.columns-container > div{
   font-family: ui-sans, "Helvetica Neue", Arial, sans-serif;
   font-size: 0.95rem;
   margin-bottom: 1rem;
-}
-
-/* Trademark Symbol */
-.columns.homepage.block.columns-2-cols .ancestry::after {
-  content: "®";
-  font-size: 0.5em;
-  vertical-align: super;
-  font-family: Arial, sans-serif;
 }
 
 /* Block styleing */
@@ -120,37 +117,16 @@ main .section.columns-container > div{
   z-index: -1;
 }
 
-/* Assign column with different color */
-.columns.homepage.block.columns-2-cols > div.bg-color-1::before {
-  background-color: var(--background-isabelline-color);
-}
-
-.columns.homepage.block.columns-2-cols > div.bg-color-2::before {
-  background-color: var(--background-color);
-}
-
-.columns.homepage.block.columns-2-cols > div.bg-color-3::before {
-  background-color:  var(--backgroung-blue-ligher-color);
-}
-
-.columns.homepage.block.columns-2-cols > div.big-color-1,
-.columns.homepage.block.columns-2-cols > div.big-color-2,
-.columns.homepage.block.columns-2-cols > div.big-color-3 {
-  margin-left: calc(-50vw + 50%);
-  margin-right: calc(-50vw + 50%);
-  width: 100vw;
-}
-
-/* DNA button with blue background */
-.columns.homepage.block.columns-2-cols .dna-button{
+/* Button with blue background in blue bg */
+.section.section-pale-blue-lighter .columns.homepage.block .button{
  background-color: var(--button-blue-color);
 }
 
-.columns.homepage.block.columns-2-cols .dna-button:hover {
+.section.section-pale-blue-lighter .columns.homepage.block .button:hover {
   background-color: var(--button-blue-hover-color);
 }
 
-.columns.homepage.block.columns-2-cols .dna-button:active {
+.section.section-pale-blue-lighter .columns.homepage.block .button:active {
   background-color: var(--button-blue-active-color);
 }
 

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -300,7 +300,7 @@ main .section.columns-container > div{
   margin: 0;
 }
 
-.columns.footer.block.columns-3-cols .button-container .button {
+.section.homepage .columns.footer.block.columns-3-cols .button-container .button {
   background-color: transparent;
   border: none;
   padding: 0;
@@ -312,9 +312,9 @@ main .section.columns-container > div{
   -webkit-font-smoothing: antialiased;
 }
 
-.columns.footer.block.columns-3-cols .button:hover,
-.columns.footer.block.columns-3-cols .button:active,
-.columns.footer.block.columns-3-cols .button:focus {
+.section.homepage .columns.footer.block.columns-3-cols .button:hover,
+.section.homepage .columns.footer.block.columns-3-cols .button:active,
+.section.homepage .columns.footer.block.columns-3-cols .button:focus {
   background-color: transparent;
   color: var(--button-blue-active-color);
   text-decoration: underline;

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -1,38 +1,3 @@
-// Function to wrap 'Ancestry' in a span with class 'ancestry' within a given element
-function wrapAncestryText(element) {
-  const ancestryRegex = /AncestryDNA|Ancestry/g;
-  function traverseNodes(node) {
-    node.childNodes.forEach((child) => {
-      if (child.nodeType === Node.TEXT_NODE) {
-        const updatedText = child.textContent.replace(ancestryRegex, (match) => `<span class="ancestry">${match}</span>`);
-        if (updatedText !== child.textContent) {
-          const wrapper = document.createElement('span');
-          wrapper.innerHTML = updatedText;
-          child.replaceWith(...wrapper.childNodes);
-        }
-      } else if (child.nodeType === Node.ELEMENT_NODE && child.nodeName !== 'SCRIPT' && child.nodeName !== 'STYLE') {
-        traverseNodes(child);
-      }
-    });
-  }
-
-  traverseNodes(element);
-}
-
-// Check for DNA icon and apply blue button background
-function checkDNAIconAndApplyClass(block) {
-  const dnaIcons = block.querySelectorAll('img[data-icon-name="icon-dna"]');
-
-  dnaIcons.forEach((dnaIcon) => {
-    const container = dnaIcon.closest('.bg-color-1, .bg-color-2, .bg-color-3');
-    const button = container.querySelector('.button');
-
-    if (button) {
-      button.classList.add('dna-button');
-    }
-  });
-}
-
 export default function decorate(block) {
   const cols = [...block.firstElementChild.children];
   block.classList.add(`columns-${cols.length}-cols`);
@@ -59,9 +24,5 @@ export default function decorate(block) {
     });
 
     const textContent = row.querySelector('.text-content');
-    if (textContent) {
-      wrapAncestryText(textContent);
-    }
   });
-  checkDNAIconAndApplyClass(block);
 }

--- a/blocks/columns/columns.js
+++ b/blocks/columns/columns.js
@@ -22,7 +22,5 @@ export default function decorate(block) {
         img.parentElement.parentElement.classList.add('icon-wrapper');
       }
     });
-
-    const textContent = row.querySelector('.text-content');
   });
 }

--- a/blocks/hero-banner/hero-banner.css
+++ b/blocks/hero-banner/hero-banner.css
@@ -22,6 +22,11 @@ main .section.hero-banner-container {
     line-height: 1.33;
 }
 
+.hero-banner .trademark {
+    font-size: 0.4em;
+    position: relative;
+}
+  
 .hero-banner > div {
     display: flex;
     flex-direction: column;
@@ -51,6 +56,9 @@ main .section.hero-banner-container {
 .hero-banner h1:only-of-type {
     margin-top: 2rem;
     margin-bottom: 1.5rem;
+    min-height: 1.8em;
+    text-align: center;
+    line-height: 1.2;
 }
 
 /* Apply to h1s that are neither first nor last, when there's more than one h1 */
@@ -106,15 +114,6 @@ main .section.hero-banner-container {
     padding: 0.7em 1.5em;
     font-size: 1rem;
     line-height: 1.25;
-}
-
-/* Ancestry Trademark Symbol */
-.hero-banner .ancestry::after {
-    content: "®";
-    font-size: 0.6em;
-    vertical-align: top;
-    position: relative;
-    top: -0.1em;
 }
 
 /* Responsive Styles */

--- a/blocks/hero-banner/hero-banner.js
+++ b/blocks/hero-banner/hero-banner.js
@@ -1,29 +1,3 @@
-// Wrap 'Ancestry' in a span with class 'ancestry' within a given element
-function wrapAncestryText(element) {
-  const ancestryRegex = /AncestryDNA|Ancestry/g;
-  function traverseNodes(node) {
-    node.childNodes.forEach((child) => {
-      if (child.nodeType === Node.TEXT_NODE) {
-        const updatedText = child.textContent.replace(ancestryRegex, (match) => {
-          if (child.parentElement && child.parentElement.classList.contains('ancestry')) {
-            return match;
-          }
-          return `<span class="ancestry">${match}</span>`;
-        });
-        if (updatedText !== child.textContent) {
-          const wrapper = document.createElement('span');
-          wrapper.innerHTML = updatedText;
-          child.replaceWith(...wrapper.childNodes);
-        }
-      } else if (child.nodeType === Node.ELEMENT_NODE && child.nodeName !== 'SCRIPT' && child.nodeName !== 'STYLE') {
-        traverseNodes(child);
-      }
-    });
-  }
-
-  traverseNodes(element);
-}
-
 function wrapImagesInContainer() {
   const heroBannerWrappers = document.querySelectorAll('.hero-banner-wrapper');
 
@@ -85,8 +59,6 @@ export default function decorate() {
       } else if (heroBanner.classList.contains('desktop-banner')) {
         wrapper.classList.add('desktop-banner-wrapper');
       }
-
-      wrapAncestryText(heroBanner);
     }
   });
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -310,12 +310,20 @@ main > .section.center p {
   font-size: 16.5px;
 }
 
+main > .section.section-white {
+  background-color: var(--background-color);
+}
+
 main > .section.section-biege {
   background-color: #FAF9F7;
 }
 
 main > .section.section-pale-blue {
   background-color: #E5F0F1;
+}
+
+main > .section.section-pale-blue-lighter {
+  background-color: var(--backgroung-blue-ligher-color);
 }
 
 main > .section.section-warm-gray {


### PR DESCRIPTION
## homepage column block re-authoring & leverage trademark automatic replacement
**Change:**
1. Break whole columns into several columns, allowing author define background colors/styles
2. Deleting the duplicate logic of handling trademarks. Leverage `decorateTrademarks `in script.js to automatically replace superscripts and style it properly.

Test URLs:
- Before: https://main--com--ancestry.aem.live/
- After: https://homepage-fix--com--ancestry.aem.page/drafts/xfeng/homepage-2
<img width="378" alt="Screenshot 2024-10-14 at 3 55 48 PM" src="https://github.com/user-attachments/assets/c6c3b0a9-5270-49fe-bba6-0dad94d10fdb">

