### PR TITLE
reference: [modal] embed youtube video

### DIFF
--- a/blocks/embed/embed.css
+++ b/blocks/embed/embed.css
@@ -1,0 +1,49 @@
+/*
+* Copyright 2021 Adobe. All rights reserved.
+* This file is licensed to you under the Apache License, Version 2.0 (the "License");
+* you may not use this file except in compliance with the License. You may obtain a copy
+* of the License at http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software distributed under
+* the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR REPRESENTATIONS
+* OF ANY KIND, either express or implied. See the License for the specific language
+* governing permissions and limitations under the License.
+*/
+.embed {
+  display: flex;
+  margin: 0 auto 2rem;
+  padding: 0;
+  flex-direction: column;
+  align-items: stretch;
+  max-width: 100%;
+}
+
+.embed > div,
+.embed blockquote,
+.embed iframe {
+  flex: 1;
+}
+
+.embed iframe {
+  border: 1px solid var(--color-gray-light-alt);
+  border-radius: .5rem;
+}
+
+.embed img {
+  max-width: 100%;
+}
+
+.embed.tiktok lite-tiktok {
+  margin: 0 auto;
+  width: 518px;
+  height: 738px;
+}
+
+.embed.instagram {
+  width: 325px;
+  min-height: 739px;
+}
+
+.embed.instagram > div {
+  display: flex;
+}

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -1,0 +1,172 @@
+import { loadCSS, loadScript } from '../../scripts/aem.js';
+
+const FALLBACK_PUBLICATION_DATE = '2013-07-18'; // go-live date for the Franklin site, but could be any value
+
+const getDefaultEmbed = (url) => `<iframe src="${url.href}" allowfullscreen allow="encrypted-media" title="Content from ${url.hostname}" loading="lazy"></iframe>`;
+
+const embedYoutubeFacade = async (url) => {
+  loadCSS('/blocks/embed/lite-yt-embed/lite-yt-embed.css');
+  loadScript('/blocks/embed/lite-yt-embed/lite-yt-embed.js');
+
+  const usp = new URLSearchParams(url.search);
+  let videoId = usp.get('v');
+  if (url.origin.includes('youtu.be')) {
+    videoId = url.pathname.substring(1);
+  } else {
+    videoId = url.pathname.split('/').pop();
+  }
+  const wrapper = document.createElement('div');
+  wrapper.setAttribute('itemscope', '');
+  wrapper.setAttribute('itemtype', 'https://schema.org/VideoObject');
+  const litePlayer = document.createElement('lite-youtube');
+  litePlayer.setAttribute('videoid', videoId);
+  wrapper.append(litePlayer);
+
+  try {
+    const response = await fetch(`https://www.youtube.com/oembed?url=http://www.youtube.com/watch?v=${videoId}`);
+    const json = await response.json();
+    wrapper.innerHTML = `
+      <meta itemprop="name" content="${json.title}"/>
+      <meta itemprop="uploadDate" content="${document.head.querySelector('[name="publication-date"]')?.content || FALLBACK_PUBLICATION_DATE}"/>
+      <link itemprop="embedUrl" href="https://www.youtube.com/embed/${videoId}"/>
+      <link itemprop="thumbnailUrl" href="${json.thumbnail_url}"/>
+      
+      ${wrapper.innerHTML}
+    `;
+  } catch (err) {
+    // Nothing to do, metadata just won't be added to the video
+  }
+  return wrapper.outerHTML;
+};
+
+const embedInstagram = (url) => {
+  const endingSlash = url.pathname.endsWith('/') ? '' : '/';
+  const location = window.location.href.endsWith('.html') ? window.location.href : `${window.location.href}.html`;
+  const src = `${url.origin}${url.pathname}${endingSlash}embed/captioned/?rd=${window.encodeURIComponent(location)}`;
+  const embedHTML = `
+    <div itemscope itemtype="https://schema.org/SocialMediaPosting">
+      <link itemprop="url" href="${url.origin}${url.pathname}${endingSlash}embed/captioned/"/>
+      <iframe src="${src}" allowfullscreen allowtransparency scrolling="no" frameborder="0" loading="lazy"></iframe>
+    </div>
+  `;
+  return embedHTML;
+};
+
+const embedTwitter = (url) => {
+  loadScript('https://platform.twitter.com/widgets.js');
+  const embedHTML = `
+    <blockquote itemscope itemtype="https://schema.org/SocialMediaPosting">
+      <a itemprop="url" href="${url}"></a>
+    </blockquote>
+  `;
+  return embedHTML;
+};
+
+const embedTiktokFacade = async (url) => {
+  loadScript('/blocks/embed/lite-tiktok/lite-tiktok.js', { async: true, type: 'module' });
+  const videoId = url.pathname.split('/').pop();
+  try {
+    const request = await fetch(`https://www.tiktok.com/oembed?url=https://www.tiktok.com/video/${videoId}`);
+    const json = await request.json();
+    return `
+      <div itemscope itemtype="https://schema.org/VideoObject">
+        <meta itemprop="name" content="${json.title}"/>
+        <meta itemprop="uploadDate" content="${document.head.querySelector('[name="publication-date"]')?.content || FALLBACK_PUBLICATION_DATE}"/>
+        <link itemprop="thumbnailUrl" href="${json.thumbnail_url}"/>
+        <link itemprop="embedUrl" href="https://www.tiktok.com/video/${videoId}"/>
+        <lite-tiktok videoid="${videoId}"></lite-tiktok>
+      </div>
+    `;
+  } catch (err) {
+    return `
+      <div itemscope itemtype="https://schema.org/VideoObject">
+        <link itemprop="embedUrl" href="https://www.tiktok.com/video/${videoId}"/>
+        <lite-tiktok videoid="${videoId}"></lite-tiktok>
+      </div>
+    `;
+  }
+};
+
+const EMBEDS_CONFIG = {
+  instagram: embedInstagram,
+  tiktok: embedTiktokFacade,
+  twitter: embedTwitter,
+  youtube: embedYoutubeFacade,
+};
+
+function getPlatform(url) {
+  const [service] = url.hostname.split('.').slice(-2, -1);
+  if (service === 'youtu') {
+    return 'youtube';
+  }
+  return service;
+}
+
+const loadEmbed = async (block, service, url) => {
+  block.classList.toggle('skeleton', true);
+
+  const embed = EMBEDS_CONFIG[service];
+  if (!embed) {
+    block.classList.toggle('generic', true);
+    block.innerHTML = getDefaultEmbed(url);
+    return;
+  }
+
+  try {
+    block.classList.toggle(service, true);
+    try {
+      block.innerHTML = await embed(url);
+    } catch (err) {
+      block.style.display = 'none';
+    } finally {
+      block.classList.toggle('skeleton', false);
+    }
+  } catch (err) {
+    block.style.maxHeight = '0px';
+  }
+};
+
+// Listen for messages from instagram embeds to update the embed height.
+window.addEventListener('message', (ev) => {
+  const iframe = [...document.querySelectorAll('iframe')].find((i) => i.contentWindow === ev.source);
+  if (!iframe) {
+    return;
+  }
+  let data;
+  try {
+    data = typeof ev.data === 'string' ? JSON.parse(ev.data) : ev.data;
+  } catch (e) {
+    // Nothing to do, the message isn't the one we are looking for
+    return;
+  }
+
+  if (data.type !== 'MEASURE') {
+    return;
+  }
+
+  iframe.closest('.block').style.height = `${data.details.height}px`;
+});
+
+/**
+ * @param {HTMLDivElement} block
+ */
+export default function decorate(block) {
+  const url = new URL(block.querySelector('a').href.replace(/%5C%5C_/, '_'));
+
+  block.textContent = '';
+  const service = getPlatform(url);
+  // Both Youtube and TikTok use an optimized lib that already leverages the intersection observer
+  if (service !== 'tiktok' && service !== 'youtube') {
+    const observer = new IntersectionObserver((entries) => {
+      if (!entries.some((e) => e.isIntersecting)) {
+        return;
+      }
+
+      loadEmbed(block, service, url);
+      observer.unobserve(block);
+    });
+    observer.observe(block);
+  } else {
+    loadEmbed(block, service, url);
+  }
+}

--- a/blocks/embed/lite-tiktok/lite-tiktok.js
+++ b/blocks/embed/lite-tiktok/lite-tiktok.js
@@ -1,0 +1,216 @@
+export class LiteTTEmbed extends HTMLElement {
+  constructor() {
+      super();
+      this.isIframeLoaded = false;
+      this.setupDom();
+  }
+  static get observedAttributes() {
+      return ['videoid', 'playlistid'];
+  }
+  connectedCallback() {
+      this.addEventListener('pointerover', LiteTTEmbed.warmConnections, {
+          once: true,
+      });
+      this.addEventListener('click', () => this.addIframe());
+  }
+  get videoId() {
+      return encodeURIComponent(this.getAttribute('videoid') || '');
+  }
+  set videoId(id) {
+      this.setAttribute('videoid', id);
+  }
+  get autoLoad() {
+      return this.hasAttribute('autoload');
+  }
+  set __data(obj) {
+      this.__data = obj;
+  }
+  get __data() {
+      return this.__data;
+  }
+  setupDom() {
+      const shadowDom = this.attachShadow({ mode: 'open' });
+      shadowDom.innerHTML = `
+    <style>
+      :host {
+        contain: content;
+        display: block;
+        position: relative;
+        width: 100%;
+        height: 735px;
+      }
+
+      #frame, iframe {
+        position: absolute;
+        width: 100%;
+        height: 100%;
+        left: 0;
+      }
+
+      #frame {
+        cursor: pointer;
+      }
+
+      #fake {
+        display: flex;
+        position: relative;
+        height: 100%;
+        justify-content: center;
+        background: #000;
+        width: 80%;
+        margin: auto;
+      }
+
+      #logo {
+        position: absolute;
+        width: 48px;
+        height: 48px;
+        margin: 1rem;
+        right: 0;
+      }
+
+      #fallbackPlaceholder {
+        height: 100%;
+        position: fixed;
+        top: 50%;
+        left: 50%;
+        transform: translate(-50%, -50%);
+      }
+
+      #playButton {
+        width: 150px;
+        height: 150px;
+        background-color: transparent;
+        z-index: 1;
+        border: 0;
+      }
+
+      #playButton:before {
+        content: '';
+        border-style: solid;
+        border-width: 22px 0 22px 40px;
+        border-color: transparent transparent transparent #fff;
+      }
+
+      #playButton,
+      #playButton:before {
+        position: absolute;
+        top: 50%;
+        left: 50%;
+        transform: translate3d(-50%, -50%, 0);
+        cursor: inherit;
+      }
+
+      /* Post-click styles */
+      .activated {
+        cursor: unset;
+      }
+
+      #frame.activated::before,
+      #frame.activated > #fake {
+        display: none;
+      }
+    </style>
+    <div id="frame">
+      <div id="fake">
+        <picture>
+          <source id="jpegPlaceholder" type="image/jpeg">
+          <img id="fallbackPlaceholder" referrerpolicy="origin" loading="lazy" alt="Video placeholder image">
+        </picture>
+        <button id="playButton" aria-label="Play"></button>
+        <svg id="logo" xmlns="http://www.w3.org/2000/svg"><path d="M19.8 19.8v-1.6L18 18a12.1 12.1 0 0 0-7 22 12 12 0 0 1 8.6-20.3Z" fill="#25F4EE"/><path d="M20 37.4c3 0 5.5-2.4 5.6-5.3V5.7h4.8L30.3 4h-6.6v26.4a5.5 5.5 0 0 1-8.1 4.7c1 1.4 2.6 2.3 4.4 2.3Zm19.4-22.7v-1.5c-1.8 0-3.5-.6-5-1.5a9 9 0 0 0 5 3Z" fill="#25F4EE"/><path d="M34.4 11.7a9.1 9.1 0 0 1-2.2-6h-1.8c.4 2.5 2 4.6 4 6ZM18.1 24.6c-3 0-5.6 2.5-5.6 5.6 0 2.1 1.3 4 3 4.9a5.5 5.5 0 0 1 6.2-8.5v-6.7l-1.7-.2h-.2v5.1l-1.7-.2Z" fill="#FE2C55"/><path d="M39.4 14.6v5.1c-3.4 0-6.6-1.1-9.2-3v13.5a12 12 0 0 1-19 10 12.1 12.1 0 0 0 21-8.3V18.5a16 16 0 0 0 9.1 3v-6.7c-.6 0-1.3 0-1.9-.2Z" fill="#FE2C55"/><path d="M30.3 30.2V16.8a15 15 0 0 0 9.1 3v-5.2c-2-.4-3.7-1.4-5-3a9.2 9.2 0 0 1-4-6h-4.8v26.5a5.5 5.5 0 0 1-10 3 5.5 5.5 0 0 1 4.2-10.2v-5.2a12.1 12.1 0 0 0-8.6 20.4 12 12 0 0 0 19-9.9Z" fill="#fff"/></svg>
+      </div>
+    </div>
+  `;
+      this.domRefFrame = shadowDom.querySelector('#frame');
+      this.domRefImg = {
+          fallback: shadowDom.querySelector('#fallbackPlaceholder'),
+          webp: shadowDom.querySelector('#webpPlaceholder'),
+          jpeg: shadowDom.querySelector('#jpegPlaceholder'),
+      };
+      this.domRefPlayButton = shadowDom.querySelector('#playButton');
+  }
+  async setupComponent() {
+      if (!this.autoLoad) {
+          const request = await fetch(`https://www.tiktok.com/oembed?url=https://www.tiktok.com/video/${this.videoId}`);
+          const data = await request.json();
+          this.initImagePlaceholder(data);
+          this.domRefPlayButton.setAttribute('aria-label', `Play: ${data.title}`);
+          this.setAttribute('title', `Play: ${data.title}`);
+      }
+      else {
+          this.initIntersectionObserver();
+      }
+  }
+  attributeChangedCallback(name, oldVal, newVal) {
+      switch (name) {
+          case 'videoid': {
+              if (oldVal !== newVal) {
+                  this.setupComponent();
+                  if (this.domRefFrame.classList.contains('activated')) {
+                      this.domRefFrame.classList.remove('activated');
+                      this.shadowRoot.querySelector('iframe').remove();
+                      this.isIframeLoaded = false;
+                  }
+              }
+              break;
+          }
+          default:
+              break;
+      }
+  }
+  addIframe(isIntersectionObserver = false) {
+      if (!this.isIframeLoaded) {
+          const iframeHTML = `
+<iframe frameborder="0"
+sandbox="allow-popups allow-popups-to-escape-sandbox allow-scripts allow-top-navigation allow-same-origin"
+src="https://www.tiktok.com/embed/v2/${this.videoId}">
+</iframe>
+`;
+          this.domRefFrame.insertAdjacentHTML('beforeend', iframeHTML);
+          this.domRefFrame.classList.add('activated');
+          this.isIframeLoaded = true;
+      }
+  }
+  initImagePlaceholder(data) {
+      this.domRefImg.jpeg.srcset = data.thumbnail_url;
+      this.domRefImg.fallback.src = data.thumbnail_url;
+      this.domRefImg.fallback.setAttribute('aria-label', `Play: ${data.title}`);
+      this.domRefImg?.fallback?.setAttribute('alt', `Play: ${data.title}`);
+  }
+  initIntersectionObserver() {
+      const options = {
+          root: null,
+          rootMargin: '0px',
+          threshold: 0,
+      };
+      const observer = new IntersectionObserver((entries, observer) => {
+          entries.forEach(entry => {
+              if (entry.isIntersecting && !this.isIframeLoaded) {
+                  LiteTTEmbed.warmConnections();
+                  this.addIframe(true);
+                  observer.unobserve(this);
+              }
+          });
+      }, options);
+      observer.observe(this);
+  }
+  static addPrefetch(kind, url) {
+      const linkElem = document.createElement('link');
+      linkElem.rel = kind;
+      linkElem.href = url;
+      linkElem.crossOrigin = 'true';
+      document.head.append(linkElem);
+  }
+  static warmConnections() {
+      if (LiteTTEmbed.isPreconnected)
+          return;
+      LiteTTEmbed.addPrefetch('preconnect', 'https://www.tiktok.com');
+      LiteTTEmbed.addPrefetch('preconnect', 'https://mcs.us.tiktok.com');
+      LiteTTEmbed.addPrefetch('preconnect', 'https://mon.us.tiktokv.com');
+      LiteTTEmbed.isPreconnected = true;
+  }
+}
+LiteTTEmbed.isPreconnected = false;
+customElements.define('lite-tiktok', LiteTTEmbed);
+//# sourceMappingURL=lite-tiktok.js.map

--- a/blocks/embed/lite-yt-embed/lite-yt-embed.css
+++ b/blocks/embed/lite-yt-embed/lite-yt-embed.css
@@ -1,0 +1,86 @@
+lite-youtube {
+  background-color: #000;
+  position: relative;
+  display: block;
+  contain: content;
+  background-position: center center;
+  background-size: cover;
+  cursor: pointer;
+  max-width: 720px;
+}
+
+/* gradient */
+lite-youtube::before {
+  content: '';
+  display: block;
+  position: absolute;
+  top: 0;
+  background-image: url(data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAADGCAYAAAAT+OqFAAAAdklEQVQoz42QQQ7AIAgEF/T/D+kbq/RWAlnQyyazA4aoAB4FsBSA/bFjuF1EOL7VbrIrBuusmrt4ZZORfb6ehbWdnRHEIiITaEUKa5EJqUakRSaEYBJSCY2dEstQY7AuxahwXFrvZmWl2rh4JZ07z9dLtesfNj5q0FU3A5ObbwAAAABJRU5ErkJggg==);
+  background-position: top;
+  background-repeat: repeat-x;
+  height: 60px;
+  padding-bottom: 50px;
+  width: 100%;
+  transition: all 0.2s cubic-bezier(0, 0, 0.2, 1);
+}
+
+/* responsive iframe with a 16:9 aspect ratio
+  thanks https://css-tricks.com/responsive-iframes/
+*/
+lite-youtube::after {
+  content: "";
+  display: block;
+  padding-bottom: calc(100% / (16 / 9));
+}
+lite-youtube > iframe {
+  width: 100%;
+  height: 100%;
+  position: absolute;
+  top: 0;
+  left: 0;
+  border: 0;
+}
+
+/* play button */
+lite-youtube > .lty-playbtn {
+  display: block;
+  width: 68px;
+  height: 48px;
+  position: absolute;
+  cursor: pointer;
+  transform: translate3d(-50%, -50%, 0);
+  top: 50%;
+  left: 50%;
+  z-index: 1;
+  background-color: transparent;
+  /* YT's actual play button svg */
+  background-image: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 68 48"><path d="M66.52 7.74c-.78-2.93-2.49-5.41-5.42-6.19C55.79.13 34 0 34 0S12.21.13 6.9 1.55c-2.93.78-4.63 3.26-5.42 6.19C.06 13.05 0 24 0 24s.06 10.95 1.48 16.26c.78 2.93 2.49 5.41 5.42 6.19C12.21 47.87 34 48 34 48s21.79-.13 27.1-1.55c2.93-.78 4.64-3.26 5.42-6.19C67.94 34.95 68 24 68 24s-.06-10.95-1.48-16.26z" fill="red"/><path d="M45 24 27 14v20" fill="white"/></svg>');
+  filter: grayscale(100%);
+  transition: filter .1s cubic-bezier(0, 0, 0.2, 1);
+  border: none;
+}
+
+lite-youtube:hover > .lty-playbtn,
+lite-youtube .lty-playbtn:focus {
+  filter: none;
+}
+
+/* Post-click styles */
+lite-youtube.lyt-activated {
+  cursor: unset;
+}
+lite-youtube.lyt-activated::before,
+lite-youtube.lyt-activated > .lty-playbtn {
+  opacity: 0;
+  pointer-events: none;
+}
+
+.lyt-visually-hidden {
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  height: 1px;
+  overflow: hidden;
+  position: absolute;
+  white-space: nowrap;
+  width: 1px;
+}

--- a/blocks/embed/lite-yt-embed/lite-yt-embed.js
+++ b/blocks/embed/lite-yt-embed/lite-yt-embed.js
@@ -1,0 +1,166 @@
+/**
+ * A lightweight youtube embed. Still should feel the same to the user, just MUCH faster to initialize and paint.
+ *
+ * Thx to these as the inspiration
+ *   https://storage.googleapis.com/amp-vs-non-amp/youtube-lazy.html
+ *   https://autoplay-youtube-player.glitch.me/
+ *
+ * Once built it, I also found these:
+ *   https://github.com/ampproject/amphtml/blob/master/extensions/amp-youtube (👍👍)
+ *   https://github.com/Daugilas/lazyYT
+ *   https://github.com/vb/lazyframe
+ */
+class LiteYTEmbed extends HTMLElement {
+  connectedCallback() {
+      this.videoId = this.getAttribute('videoid');
+
+      let playBtnEl = this.querySelector('.lty-playbtn');
+      // A label for the button takes priority over a [playlabel] attribute on the custom-element
+      this.playLabel = (playBtnEl && playBtnEl.textContent.trim()) || this.getAttribute('playlabel') || 'Play';
+
+      /**
+       * Lo, the youtube placeholder image!  (aka the thumbnail, poster image, etc)
+       *
+       * See https://github.com/paulirish/lite-youtube-embed/blob/master/youtube-thumbnail-urls.md
+       *
+       * TODO: Do the sddefault->hqdefault fallback
+       *       - When doing this, apply referrerpolicy (https://github.com/ampproject/amphtml/pull/3940)
+       * TODO: Consider using webp if supported, falling back to jpg
+       */
+      if (!this.style.backgroundImage) {
+        this.style.backgroundImage = `url("https://i.ytimg.com/vi/${this.videoId}/hqdefault.jpg")`;
+      }
+
+      // Set up play button, and its visually hidden label
+      if (!playBtnEl) {
+          playBtnEl = document.createElement('button');
+          playBtnEl.type = 'button';
+          playBtnEl.classList.add('lty-playbtn');
+          this.append(playBtnEl);
+      }
+      if (!playBtnEl.textContent) {
+          const playBtnLabelEl = document.createElement('span');
+          playBtnLabelEl.className = 'lyt-visually-hidden';
+          playBtnLabelEl.textContent = this.playLabel;
+          playBtnEl.append(playBtnLabelEl);
+      }
+      playBtnEl.removeAttribute('href');
+
+      // On hover (or tap), warm up the TCP connections we're (likely) about to use.
+      this.addEventListener('pointerover', LiteYTEmbed.warmConnections, {once: true});
+
+      // Once the user clicks, add the real iframe and drop our play button
+      // TODO: In the future we could be like amp-youtube and silently swap in the iframe during idle time
+      //   We'd want to only do this for in-viewport or near-viewport ones: https://github.com/ampproject/amphtml/pull/5003
+      this.addEventListener('click', this.addIframe);
+
+      // Chrome & Edge desktop have no problem with the basic YouTube Embed with ?autoplay=1
+      // However Safari desktop and most/all mobile browsers do not successfully track the user gesture of clicking through the creation/loading of the iframe,
+      // so they don't autoplay automatically. Instead we must load an additional 2 sequential JS files (1KB + 165KB) (un-br) for the YT Player API
+      // TODO: Try loading the the YT API in parallel with our iframe and then attaching/playing it. #82
+      this.needsYTApiForAutoplay = navigator.vendor.includes('Apple') || navigator.userAgent.includes('Mobi');
+  }
+
+  /**
+   * Add a <link rel={preload | preconnect} ...> to the head
+   */
+  static addPrefetch(kind, url, as) {
+      const linkEl = document.createElement('link');
+      linkEl.rel = kind;
+      linkEl.href = url;
+      if (as) {
+          linkEl.as = as;
+      }
+      document.head.append(linkEl);
+  }
+
+  /**
+   * Begin pre-connecting to warm up the iframe load
+   * Since the embed's network requests load within its iframe,
+   *   preload/prefetch'ing them outside the iframe will only cause double-downloads.
+   * So, the best we can do is warm up a few connections to origins that are in the critical path.
+   *
+   * Maybe `<link rel=preload as=document>` would work, but it's unsupported: http://crbug.com/593267
+   * But TBH, I don't think it'll happen soon with Site Isolation and split caches adding serious complexity.
+   */
+  static warmConnections() {
+      if (LiteYTEmbed.preconnected) return;
+
+      // The iframe document and most of its subresources come right off youtube.com
+      LiteYTEmbed.addPrefetch('preconnect', 'https://www.youtube-nocookie.com');
+      // The botguard script is fetched off from google.com
+      LiteYTEmbed.addPrefetch('preconnect', 'https://www.google.com');
+
+      // Not certain if these ad related domains are in the critical path. Could verify with domain-specific throttling.
+      LiteYTEmbed.addPrefetch('preconnect', 'https://googleads.g.doubleclick.net');
+      LiteYTEmbed.addPrefetch('preconnect', 'https://static.doubleclick.net');
+
+      LiteYTEmbed.preconnected = true;
+  }
+
+  fetchYTPlayerApi() {
+      if (window.YT || (window.YT && window.YT.Player)) return;
+
+      this.ytApiPromise = new Promise((res, rej) => {
+          var el = document.createElement('script');
+          el.src = 'https://www.youtube.com/iframe_api';
+          el.async = true;
+          el.onload = _ => {
+              YT.ready(res);
+          };
+          el.onerror = rej;
+          this.append(el);
+      });
+  }
+
+  async addYTPlayerIframe(params) {
+      this.fetchYTPlayerApi();
+      await this.ytApiPromise;
+
+      const videoPlaceholderEl = document.createElement('div')
+      this.append(videoPlaceholderEl);
+
+      const paramsObj = Object.fromEntries(params.entries());
+
+      new YT.Player(videoPlaceholderEl, {
+          width: '100%',
+          videoId: this.videoId,
+          playerVars: paramsObj,
+          events: {
+              'onReady': event => {
+                  event.target.playVideo();
+              }
+          }
+      });
+  }
+
+  async addIframe(){
+      if (this.classList.contains('lyt-activated')) return;
+      this.classList.add('lyt-activated');
+
+      const params = new URLSearchParams(this.getAttribute('params') || []);
+      params.append('autoplay', '1');
+      params.append('playsinline', '1');
+
+    //   if (this.needsYTApiForAutoplay) {
+          return this.addYTPlayerIframe(params);
+    //   }
+
+      const iframeEl = document.createElement('iframe');
+      iframeEl.width = 560;
+      iframeEl.height = 315;
+      // No encoding necessary as [title] is safe. https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html#:~:text=Safe%20HTML%20Attributes%20include
+      iframeEl.title = this.playLabel;
+      iframeEl.allow = 'accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture';
+      iframeEl.allowFullscreen = true;
+      // AFAIK, the encoding here isn't necessary for XSS, but we'll do it only because this is a URL
+      // https://stackoverflow.com/q/64959723/89484
+      iframeEl.src = `https://www.youtube-nocookie.com/embed/${encodeURIComponent(this.videoId)}?${params.toString()}`;
+      this.append(iframeEl);
+
+      // Set focus for a11y
+      iframeEl.focus();
+  }
+}
+// Register custom element
+customElements.define('lite-youtube', LiteYTEmbed);


### PR DESCRIPTION
This is an implementation example  from https://github.com/hlxsites/petplace/tree/main/blocks/embed, could be a good reference for our embed video in the modal.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--com--ancestry.aem.live/
- After: https://embeded--com--ancestry.aem.page/drafts/xfeng/embed


<img width="494" alt="Screenshot 2024-10-16 at 3 34 39 PM" src="https://github.com/user-attachments/assets/81df5022-f9e4-4615-93e7-1fabddf9ed8c">
<img width="382" alt="Screenshot 2024-10-16 at 3 35 06 PM" src="https://github.com/user-attachments/assets/7e5f06f3-41d1-4a32-a4d0-b113b9431388">

