### PR TITLE
prelim: implement Modal (carousel) 

### DIFF
--- a/blocks/carousel/carousel.css
+++ b/blocks/carousel/carousel.css
@@ -1,19 +1,17 @@
-/* Base styling for the carousel container and wrapper */
 .section.carousel-container {
   display: flex;
   justify-content: center;
   align-items: center;
   text-align: center;
-  width: 100%;
-  background-color: #d9e7d4;
-  font-size: 1.8rem;
   position: relative;
   padding: 2rem;
   margin: 0;
   box-sizing: border-box;
   overflow: hidden;
-  height: auto;
-  min-height: 300px;
+}
+
+.section.modal.carousel-container {
+  padding: 0;
 }
 
 .carousel-wrapper {
@@ -24,71 +22,61 @@
   align-items: center;
 }
 
-.carousel.block {
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  width: 100%;
+.carousel {
   position: relative;
-  max-width: 100%;
+  width: 100%;
+  min-height: 600px;
   overflow: hidden;
-  min-height: 500px; /* Set a minimum height */
 }
 
-/* Carousel items (individual slides) */
-.carousel.block > div {
-  display: none;
-  transition: opacity 0.5s ease;
+.carousel > div {
+  position: absolute;
+  top: 0;
+  left: 0;
   width: 100%;
+  height: 100%;
+  z-index: 1;
+  opacity: 0;
+  visibility: hidden;
+  transition: transform 2.8s ease-in-out, opacity 3.8s ease-in-out;
+  transform: translateX(200%);
+}
+
+.carousel  > div.active {
+  transform: translateX(0);
+  opacity: 1;
+  visibility: visible;
+  z-index: 2;
+}
+
+.carousel > div.previous {
+  transform: translateX(-100%);
+  opacity: 0.9;
+  visibility: visible;
   z-index: 1;
 }
 
-.carousel.block > div.active {
-  display: block;
+.carousel > div.next {
+  transform: translateX(100%);
+  opacity: 0.9;
+  visibility: visible;
+  z-index: 1;
+}
+
+.carousel > div.active > * {
   opacity: 1;
-  transition: opacity 0.5s ease;
+  visibility: visible;
 }
 
-/* Content within each carousel slide */
-.carousel.block > div > div {
-  min-height: 500px;
-  display: flex;
-  flex-direction: column;
-  justify-content: center;
-  align-items: center;
-  max-width: 100%;
-  padding: 3rem;
-  position: relative;
-}
-
-.carousel.block > div > div::before,
-.carousel.block > div > div::after {
-  content: none;
-}
-
-/* Add left and right quotes to the carousel block */
-.carousel.block::before {
-  content: url('../../icons/quote-left.png');
-  position: absolute;
-  top: 20%;
-  left: 5%;
-  width: 50px;
+.carousel picture img {
+  width: auto;
   height: auto;
-  z-index: 2;
+  max-width: 90%;
+  display: block;
+  margin: 0 auto;
+  object-fit: cover;
 }
 
-.carousel.block::after {
-  content: url('../../icons/quote-right.png');
-  position: absolute;
-  bottom: 20%;
-  right: 5%;
-  width: 50px;
-  height: auto;
-  z-index: 2;
-}
-
-/* Icon styling */
 .carousel .icon {
   display: inline-block;
   margin: 0.5rem;
@@ -101,7 +89,6 @@
   max-width: 100%;
 }
 
-/* Paragraph styling */
 .carousel.block p {
   text-align: center;
   margin: 0.5rem 1rem;
@@ -116,7 +103,39 @@
   font-size: 1.1rem;
 }
 
-/* Indicators styling */
+.carousel .button-container {
+  position: absolute;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  text-align: center;
+  width: 100%;
+  white-space: normal;
+  overflow: visible;
+}
+
+.carousel .button-container .button {
+  margin: auto;
+  font-weight: 700;
+  overflow: visible;
+  white-space: wrap;
+  width: auto;
+  word-break: keep-all;
+  margin-bottom: 0.5rem;
+}
+
+.carousel.block .button-container a {
+  background-color: var(--button-blue-color);
+}
+
+.carousel.block .button-container a:hover {
+  background-color: var(--button-blue-hover-color);
+}
+
+.carousel.block .button-container a:active {
+  background-color: var(--button-blue-active-color);
+}
+
 .carousel.block .indicators {
   position: absolute;
   bottom: 5%;
@@ -148,7 +167,6 @@
   background-color: var(--light-color);
 }
 
-/* Carousel navigation buttons (Previous/Next) */
 .carousel-actions {
   position: absolute;
   top: 50%;
@@ -162,11 +180,13 @@
 }
 
 .carousel-actions button {
-  background-color: transparent;
+  background-color: #e2e0dd;
   border: none;
   padding: 0;
   cursor: pointer;
   pointer-events: all;
+  border-radius: 100%;
+  height: 50px;
 }
 
 .carousel-actions .previous::before,
@@ -174,29 +194,118 @@
   content: '';
   display: inline-block;
   width: 50px;
-  height: 50px;
   mask-size: contain;
   mask-repeat: no-repeat;
   background-color: var(--light-color);
 }
 
 .carousel-actions .previous::before {
-  mask-image: url('../../icons/arrow-prev.svg');
+  font-family: ancestry-icon, sans-serif;
+  content: "\e620";
+  color: #383838;
+  font-size: 1.2rem;
+  font-weight: 400;
+  background-color: #e2e0dd;
 }
 
 .carousel-actions .next::before {
-  mask-image: url('../../icons/arrow-next.svg');
+  font-family: ancestry-icon, sans-serif;
+  content: "\e61f";
+  color: #383838;
+  font-size: 1.2rem;
+  font-weight: 400;
+  background-color: #e2e0dd;
 }
 
-/* Hide navigation buttons and indicators when there's only one slide */
 .carousel-wrapper.single-slide .carousel-actions,
 .carousel-wrapper.single-slide .indicators {
   display: none;
 }
 
-/* Hide carousel container on smaller screens */
+.section .carousel .next h1,
+.section .carousel .previous h1,
+.section .carousel .next h2,
+.section .carousel .previous h2 {
+  color: transparent;
+}
+
+.carousel .trademark,
+.carousel .superscript {
+  font-size: 0.5em;
+}
+
+.section.section-dark-gray {
+  background-color: #2d3136;
+  padding: 0 2rem;
+}
+
+.section.section-dark-gray .carousel h2 {
+  font-family: ui-sans, 'Helvetica Neue', Arial, sans-serif;
+  color: #a9a9a9;
+  font-size: 2rem;
+  margin-bottom: 2rem;
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
+}
+
+.section.section-dark-gray .carousel strong {
+  color: white;
+  font-size: 1.4rem;
+  margin-bottom: 2rem;
+  font-weight: 700;
+  -webkit-font-smoothing: antialiased;
+}
+
+.section.section-dark-gray .carousel p:not(:has(picture)) {
+  color: white;
+  font-size: 0.6em;
+  font-weight: 400;
+  -webkit-font-smoothing: antialiased;
+  max-width: 80%;
+  margin: auto;
+}
+
 @media (max-width: 900px) {
- .section.carousel-container {
-  display:none;
- }
+  .section.carousel-container.desktop {
+    display: none;
+  }
+
+  .section.carousel-container.mobile {
+    display: block;
+  }
+
+  .section.section-dark-gray .carousel h2 {
+    font-size: 1.2em;
+    margin: 2rem;
+  }
+
+  .carousel.block {
+    min-height: 580px;
+  }
+
+  .section.section-dark-gray .carousel p strong {
+    font-size: 1.5em;
+  }
+
+  .section.section-dark-gray .carousel p:not(:has(picture)) {
+    font-size: 0.6em;
+    max-width: 80%;
+  }
+}
+
+@media (max-width: 600px) {
+  .carousel.block {
+    min-height: 430px;
+  }
+
+  .section.section-dark-gray .carousel p:not(:has(picture)) {
+    font-size: 0.5em;
+    max-width: 80%;
+    line-height: 1.3;
+  }
+
+  .section.section-dark-gray .carousel h2 {
+    font-size: 1rem;
+    margin: 2rem;
+  }
 }

--- a/blocks/carousel/carousel.js
+++ b/blocks/carousel/carousel.js
@@ -27,7 +27,7 @@ function handleCarouselAction(block, direction, targetIndex = null) {
 }
 
 // Add navigation buttons (Previous/Next) to the carousel
-function appendCarouselActions(block) {
+export function appendCarouselActions(block) {
   const carouselWrapper = block.parentElement;
   const carouselActions = document.createElement('div');
   carouselActions.classList.add('carousel-actions');
@@ -53,7 +53,7 @@ function appendCarouselActions(block) {
 }
 
 // Add indicators for each slide in the carousel
-function appendCarouselIndicators(block) {
+export function appendCarouselIndicators(block) {
   [...block.children].forEach((child, i) => {
     const indicatorContainer = document.createElement('ol');
     indicatorContainer.classList.add('indicators');

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -69,6 +69,69 @@ main .section.columns-container > div{
   margin-bottom: 1rem;
 }
 
+.columns.testimonial{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  padding: 5rem 10rem;
+  width: 100%;
+  box-sizing: border-box;
+  position: relative;
+}
+
+.columns.testimonial p:nth-of-type(2)::before {
+  content: "";
+  display: block;
+  width: 80px;
+  height: 80px;
+  background-image: url("/icons/quote-left.png");
+  background-size: contain;
+  background-repeat: no-repeat;
+  position: absolute;
+  top: -10px;
+  left: -40px;
+  z-index: 1;
+}
+
+.columns.testimonial p:nth-of-type(2)::after {
+  content: "";
+  display: block;
+  width: 80px;
+  height: 80px;
+  background-image: url("/icons/quote-right.png");
+  background-size: contain;
+  background-repeat: no-repeat;
+  position: absolute;
+  bottom: -10px;
+  right: -40px;
+  z-index: 1;
+}
+
+.columns.testimonial p {
+  padding :0 3rem;
+  font-size: 1.8rem;
+  font-weight: 700;
+  max-width :1200px;
+  color:var(--text-gray-dark-color);
+}
+
+.columns.testimonial p:nth-of-type(2) {
+  padding-left: 50px;;
+  padding-right: 50px;
+  position: relative;
+}
+
+.columns.testimonial .columns-img-col{
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.columns.testimonial > div > .columns-img-col img {
+  min-width: 120px;
+}
+
 /* Block styleing */
 .columns.homepage.block.columns-2-cols > div {
   position: relative;
@@ -132,6 +195,22 @@ main .section.columns-container > div{
 
 /* Mobile-specific adjustments */
 @media (max-width: 899px) {
+  .columns.testimonial{
+    padding: 5rem;
+  }
+
+  .columns.testimonial::before {
+    width: 80px;
+    height: 80px;
+    top: 8rem;
+    left: 3rem;
+  }
+  
+  .columns.testimonial::after {
+    bottom: 8rem;
+    right: 3rem;
+  }
+
   .columns.homepage.block.columns-2-cols > div {
     display: flex;
     flex-direction: column;
@@ -331,6 +410,10 @@ main .section.columns-container > div{
 }
 
 @media (max-width: 750px) {
+  .columns.testimonial {
+    display:none;
+  }
+
   .columns.footer.block.columns-3-cols > div {
     flex-direction: column;
     align-items: center;

--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -31,11 +31,12 @@
   
   .popup-close {
     position: absolute;
-    top: 5px;
-    right: 20px;
+    top: -10px;
+    right: 2px;
     font-optical-sizing: auto;
     font-size: 30px;
     cursor: pointer;
+    z-index: 1001;
   }
   
   .popup-window ul {
@@ -85,3 +86,7 @@
     text-align: center;
   }
   
+  .popup-window[data-popup-content="section carousel-container"] {
+    width: 80%;
+    max-width: 800px;
+  }

--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -28,6 +28,11 @@
     z-index: 1000;
     box-shadow: none;
   }
+
+  .popup-window[data-popup-content*="carousel-container"] {
+    width: 100%;
+    max-width: 920px;
+  }
   
   .popup-close {
     position: absolute;

--- a/blocks/modal/modal.js
+++ b/blocks/modal/modal.js
@@ -1,3 +1,6 @@
+import appendCarouselActions from '../../blocks/carousel/carousel.js';
+import appendCarouselIndicators from '../../blocks/carousel/carousel.js';
+
 export default function decorate(block) {
   function closeExistingPopups() {
     const existingPopup = document.querySelector('.popup-window');
@@ -8,17 +11,19 @@ export default function decorate(block) {
     document.body.classList.remove('no-scroll');
   }
 
-  function openPopup(content) {
+  function openPopup(content, attr='') {
     closeExistingPopups();
 
     document.body.classList.add('no-scroll');
 
     const overlay = document.createElement('div');
+    overlay.setAttribute('data-popup-overlay', attr);
     overlay.classList.add('popup-overlay');
     overlay.addEventListener('click', closeExistingPopups);
 
     const popup = document.createElement('div');
     popup.classList.add('popup-window');
+    popup.setAttribute('data-popup-content', attr);
 
     const closeButton = document.createElement('span');
     closeButton.innerHTML = '&times;';
@@ -32,6 +37,8 @@ export default function decorate(block) {
     document.body.appendChild(popup);
 
     popup.addEventListener('click', (e) => e.stopPropagation());
+
+    reinitializeCarousel(popup);
   }
 
   document.addEventListener('click', (event) => {
@@ -44,13 +51,36 @@ export default function decorate(block) {
       const id = href.substring(1);
 
       const popupContentElement = block.querySelector(`#${id}`);
-      if (popupContentElement) {
+      const condition = `[data-fragment-id="${id}"][data-popup-content="true"]`;
+      const popupContentFragmentElement = document.querySelector(condition);
+      if (popupContentFragmentElement) {
+        const fragmentContent = popupContentFragmentElement.querySelector('div .section').cloneNode(true);
+        console.log("Fragment content:", fragmentContent);
+        openPopup(fragmentContent, fragmentContent.classList);
+      } else if(popupContentElement) {
         const content = popupContentElement.parentElement.cloneNode(true);
-        openPopup(content);
+        openPopup(content)
       } else {
-        /* eslint-disable no-console */
         console.error(`Popup content not found for id: ${id}`);
       }
+    }
+  });
+}
+
+function reinitializeCarousel(popup) {
+  const carouselBlocks = popup.querySelectorAll('.carousel.block');
+
+  carouselBlocks.forEach((carousel) => {
+    const slides = [...carousel.children];
+    const slideCount = slides.length;
+
+    if (slideCount > 0) {
+      slides[0].classList.add('active');
+    }
+
+    if (slideCount > 1) {
+      appendCarouselActions(carousel);
+      appendCarouselIndicators(carousel);
     }
   });
 }

--- a/blocks/modal/modal.js
+++ b/blocks/modal/modal.js
@@ -1,4 +1,4 @@
-import { appendCarouselActions, appendCarouselIndicators } from '../carousel/carousel.js';
+import { appendCarouselActions } from '../carousel/carousel.js';
 
 function reinitializeCarousel(popup) {
   const carouselBlocks = popup.querySelectorAll('.carousel.block');
@@ -13,7 +13,6 @@ function reinitializeCarousel(popup) {
 
     if (slideCount > 1) {
       appendCarouselActions(carousel);
-      appendCarouselIndicators(carousel);
     }
   });
 }

--- a/blocks/modal/modal.js
+++ b/blocks/modal/modal.js
@@ -1,5 +1,22 @@
-import appendCarouselActions from '../../blocks/carousel/carousel.js';
-import appendCarouselIndicators from '../../blocks/carousel/carousel.js';
+import { appendCarouselActions, appendCarouselIndicators } from '../carousel/carousel.js';
+
+function reinitializeCarousel(popup) {
+  const carouselBlocks = popup.querySelectorAll('.carousel.block');
+
+  carouselBlocks.forEach((carousel) => {
+    const slides = [...carousel.children];
+    const slideCount = slides.length;
+
+    if (slideCount > 0) {
+      slides[0].classList.add('active');
+    }
+
+    if (slideCount > 1) {
+      appendCarouselActions(carousel);
+      appendCarouselIndicators(carousel);
+    }
+  });
+}
 
 export default function decorate(block) {
   function closeExistingPopups() {
@@ -11,7 +28,7 @@ export default function decorate(block) {
     document.body.classList.remove('no-scroll');
   }
 
-  function openPopup(content, attr='') {
+  function openPopup(content, attr = '') {
     closeExistingPopups();
 
     document.body.classList.add('no-scroll');
@@ -55,32 +72,14 @@ export default function decorate(block) {
       const popupContentFragmentElement = document.querySelector(condition);
       if (popupContentFragmentElement) {
         const fragmentContent = popupContentFragmentElement.querySelector('div .section').cloneNode(true);
-        console.log("Fragment content:", fragmentContent);
         openPopup(fragmentContent, fragmentContent.classList);
-      } else if(popupContentElement) {
+      } else if (popupContentElement) {
         const content = popupContentElement.parentElement.cloneNode(true);
-        openPopup(content)
+        openPopup(content);
       } else {
+        // eslint-disable-next-line no-console
         console.error(`Popup content not found for id: ${id}`);
       }
-    }
-  });
-}
-
-function reinitializeCarousel(popup) {
-  const carouselBlocks = popup.querySelectorAll('.carousel.block');
-
-  carouselBlocks.forEach((carousel) => {
-    const slides = [...carousel.children];
-    const slideCount = slides.length;
-
-    if (slideCount > 0) {
-      slides[0].classList.add('active');
-    }
-
-    if (slideCount > 1) {
-      appendCarouselActions(carousel);
-      appendCarouselIndicators(carousel);
     }
   });
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -35,7 +35,7 @@ export function decorateTooltipAndModalLinks(main) {
       } else if (tooltipParent) {
         linkElement.setAttribute('data-tooltip', 'true');
         linkElement.setAttribute('data-tooltip-id', id);
-      } else if(fragmentModalParent) {
+      } else if (fragmentModalParent) {
         linkElement.setAttribute('data-popup', 'true');
         linkElement.setAttribute('data-fragment-id', id);
         fragmentModalParent.setAttribute('data-fragment-id', id);
@@ -165,8 +165,6 @@ function addBackgroundImageToSections(main) {
     });
   });
 }
-
-
 
 /**
  * Decorates the main element.

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -29,11 +29,17 @@ export function decorateTooltipAndModalLinks(main) {
     if (targetElement) {
       const modalParent = targetElement.closest('.modal');
       const tooltipParent = targetElement.closest('.tooltips');
+      const fragmentModalParent = targetElement.closest('.fragment');
       if (modalParent) {
         linkElement.setAttribute('data-popup', 'true');
       } else if (tooltipParent) {
         linkElement.setAttribute('data-tooltip', 'true');
         linkElement.setAttribute('data-tooltip-id', id);
+      } else if(fragmentModalParent) {
+        linkElement.setAttribute('data-popup', 'true');
+        linkElement.setAttribute('data-fragment-id', id);
+        fragmentModalParent.setAttribute('data-fragment-id', id);
+        fragmentModalParent.setAttribute('data-popup-content', true);
       } else {
         // eslint-disable-next-line no-console
         console.log(`No matching container for link: ${linkElement}`);
@@ -159,6 +165,8 @@ function addBackgroundImageToSections(main) {
     });
   });
 }
+
+
 
 /**
  * Decorates the main element.

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -346,6 +346,10 @@ main > .section.section-pale-green {
   background-color: #E4EFE7;
 }
 
+main > .section.section-dark-gray {
+  background-color: #2d3136;
+}
+
 main > .section > div {
   max-width: 1200px;
   margin: auto;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -346,6 +346,10 @@ main > .section.section-pale-green {
   background-color: #E4EFE7;
 }
 
+main > .section.section-dark-green {
+  background-color: #CEDCCA;
+}
+
 main > .section.section-dark-gray {
   background-color: #2d3136;
 }


### PR DESCRIPTION
## implement Modal for Carousel block

Fix #50 

Test URLs:
- Before: https://main--com--ancestry.aem.live/
- After: https://modal-carousel--com--ancestry.aem.page/drafts/xfeng/embed

### Implementation:
<img width="519" alt="Screenshot 2024-10-23 at 7 18 47 PM" src="https://github.com/user-attachments/assets/d9a84f74-b076-4293-8e79-5fe58b52d769">


### Doc Authoring:
**Add link # to text that points to the fragment block at the end of the page**
<img width="387" alt="Screenshot 2024-10-22 at 2 47 11 PM" src="https://github.com/user-attachments/assets/9f962b24-a9a8-4d9c-91dd-aceb1ec0883a">

**Add `fragment` block with` h1, h2 or h3 ... `as the id and the url points to another content page**
<img width="387" alt="Screenshot 2024-10-22 at 2 47 22 PM" src="https://github.com/user-attachments/assets/bb10e540-0b53-4fef-90c6-d0b657126aee">

**remote page**
<img width="387" alt="Screenshot 2024-10-22 at 2 47 33 PM" src="https://github.com/user-attachments/assets/eaee838a-24c3-4aec-bbfd-2a5fea5b6f9e">



## TODO

- restyle carousel
- polish logic

