### PR TITLE
Tbt fix 2

### DIFF
--- a/blocks/survey/survey.css
+++ b/blocks/survey/survey.css
@@ -52,8 +52,6 @@
     text-align: center;
   }
 
-  
-
   .survey-container.animate-container.hidden {
     animation: reduce-height 1s ease-in-out;
     overflow: hidden;
@@ -73,6 +71,9 @@
     display: flex;
     position: relative;
     justify-content: center;
+    flex-wrap: wrap;
+    gap: 5px;
+    padding: 0 3rem;
   }
 
   .survey-container .animate li {
@@ -88,6 +89,8 @@
     cursor: pointer;
     border-radius: 8px;
     list-style: none;
+    min-width: 150px;
+    flex: 1;
   }
 
   .survey-container .animate li input {
@@ -115,6 +118,9 @@
     font-size: 17px;
     width: 100%;
     height: 100%;
+    text-align: center;
+    word-wrap: break-word;
+    hyphens: auto;
   }
 
   .survey-container .animate p {
@@ -156,14 +162,33 @@
     justify-content: end;
     display: flex;
   }
-  
+
   .close-button {
+    background-color: transparent;
     font-size: 16px;
     color: var(--black-color) !important;
   }
 
-  .close-button:hover {
+  .close-button:hover,
+  .close-button:active,
+  .close-button:focus {
+    background-color: transparent;
     text-decoration: none;
     cursor: pointer;
+  }
+
+  @media (max-width: 600px) {
+    .survey-container .animate li {
+        width: 100%;
+        margin: 0;
+    }
+
+    .survey-container .animate li label {
+        font-size: 15px;
+    }
+
+    .survey-container .animate h2 {
+      font-size: 1rem;
+    }
   }
   

--- a/blocks/survey/survey.js
+++ b/blocks/survey/survey.js
@@ -28,30 +28,26 @@ function createRadioFromList() {
 }
 
 export default async function decorate(block) {
-  // create a div with a cross button when clicked do same as close button
-  if (block.classList.contains('animate')) {
-    const closeDiv = document.createElement('div');
-    closeDiv.classList.add('close-div');
-    closeDiv.innerHTML = '<a href="#" class="close-button">X</a>';
-    block.prepend(closeDiv);
-
+  const closeButtonTemplate = '<div class="close-div"><a href="#" class="close-button">X</a></div>';
+  const isAnimated = block.classList.contains('animate');
+  if (isAnimated) {
+    block.insertAdjacentHTML('afterbegin', closeButtonTemplate);
     createRadioFromList();
-
-    const dismissButton = block.querySelector('p a[title=Dismiss]');
+    const dismissButton = block.querySelector('[title="Dismiss"]');
     if (dismissButton) {
-      dismissButton.setAttribute('href', '#');
+      dismissButton.href = '#';
     }
   }
 
-  document.querySelectorAll('.survey-container').forEach((container) => {
-    if (container.querySelector('.animate')) {
-      window.requestAnimationFrame(() => {
-        container.classList.add('animate-container');
-      });
-    } else if (container.querySelector('.fixed')) {
-      container.classList.add('fixed-container');
-    }
-  });
+  const container = block.closest('.survey-container');
+  if (!container) return;
+  if (isAnimated) {
+    requestAnimationFrame(() => {
+      container.classList.add('animate-container');
+    });
+  } else if (block.classList.contains('fixed')) {
+    container.classList.add('fixed-container');
+  }
 
   document.querySelectorAll('.animate input[type="radio"]').forEach((radio) => {
     radio.addEventListener('change', () => {
@@ -96,13 +92,12 @@ export default async function decorate(block) {
 
   // close survey on Dismiss/Close button click
   const dismissButton = document.querySelector('.animate .button-container:nth-of-type(2) a:first-of-type');
-  const closeButton = document.querySelector('.close-button');
-  const surveyContainer = document.querySelector('.survey-container.animate-container');
+  const closeButtonElement = document.querySelector('.close-button');
 
-  const buttons = [dismissButton, closeButton].filter((button) => button !== null);
+  const buttons = [dismissButton, closeButtonElement].filter((button) => button !== null);
   buttons.forEach((button) => {
     button.addEventListener('click', () => {
-      surveyContainer.classList.add('hidden');
+      container.classList.add('hidden');
     });
   });
 }

--- a/blocks/survey/survey.js
+++ b/blocks/survey/survey.js
@@ -45,7 +45,9 @@ export default async function decorate(block) {
 
   document.querySelectorAll('.survey-container').forEach((container) => {
     if (container.querySelector('.animate')) {
-      container.classList.add('animate-container');
+      window.requestAnimationFrame(() => {
+        container.classList.add('animate-container');
+      });
     } else if (container.querySelector('.fixed')) {
       container.classList.add('fixed-container');
     }

--- a/blocks/survey/survey.js
+++ b/blocks/survey/survey.js
@@ -28,14 +28,14 @@ function createRadioFromList() {
 }
 
 export default async function decorate(block) {
-  const closeButtonTemplate = '<div class="close-div"><a href="#" class="close-button">X</a></div>';
+  const closeButtonTemplate = '<div class="close-div"><button type="button" class="close-button" aria-label="Close survey">X</button></div>';
   const isAnimated = block.classList.contains('animate');
   if (isAnimated) {
     block.insertAdjacentHTML('afterbegin', closeButtonTemplate);
     createRadioFromList();
-    const dismissButton = block.querySelector('[title="Dismiss"]');
+    const dismissButton = block.querySelector('button[aria-label="Dismiss survey"]');
     if (dismissButton) {
-      dismissButton.href = '#';
+      dismissButton.setAttribute('type', 'button');
     }
   }
 
@@ -91,13 +91,13 @@ export default async function decorate(block) {
   }
 
   // close survey on Dismiss/Close button click
-  const dismissButton = document.querySelector('.animate .button-container:nth-of-type(2) a:first-of-type');
+  const dismissButton = document.querySelector('.animate .button-container:nth-of-type(2) button[aria-label="Dismiss survey"]');
   const closeButtonElement = document.querySelector('.close-button');
 
   const buttons = [dismissButton, closeButtonElement].filter((button) => button !== null);
   buttons.forEach((button) => {
     button.addEventListener('click', () => {
-      container.classList.add('hidden');
+      container.hidden = true;
     });
   });
 }

--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -18,7 +18,12 @@ export default async function decorate(block) {
     else tbody.append(row);
     [...child.children].forEach((col) => {
       const cell = buildCell(header ? i : i + 1);
-      cell.innerHTML = col.innerHTML;
+      const content = col.innerHTML.trim();
+      if (['✓ᐩ', '✓', 'ᐩ', 'ⓘ', '✕'].includes(content.replace(/<\/?p>/g, ''))) {
+        cell.textContent = content.replace(/<\/?p>/g, '');
+      } else {
+        cell.innerHTML = col.innerHTML;
+      }
       row.append(cell);
     });
   });


### PR DESCRIPTION
Test URLs:
- Before: https://main--com--ancestry.aem.live/
- After: https://tbt-fix-2--com--ancestry.aem.page/en/c/dna

Thanks to @ramboz 's guidance and idea, here is some interesting trial that improve the `decorateTrademark`'s performance.

❌ not adopt  ✅ adopt

**1. `IntersectionObserver` and only decorate the trademarks that are in the viewport.  ❌**
    - Trademark is not that heavy.
    - We're already using batching, or using `requestIdleCallback` for scheduling
    - Some superscript and “trademarks” should already be ready when users scroll, in our case like tick, tickplus… Delaying processing might have visual "jumps".
 
**2. generic `scheduleProcessing()`  ✅**

 -  **method 1: 'requestIdleCallback()'❌**
```
 // I refered to  https://developer.chrome.com/blog/using-requestidlecallback
// this is a simpler version of the doc example, because we only need to meet
// 1. Break up work into chunks
// 2. Not block the main thread
// 3. Complete all trademark processing
function scheduleProcessing(processor, options = { timeout: 1000 }) {
  if ('requestIdleCallback' in window) {
    requestIdleCallback(deadline => {
      if (processor(deadline)) {
        scheduleProcessing(processor, options);
      }
    }, { timeout: options.timeout });
  } else {
    const start = Date.now();
    setTimeout(() => {
      const deadline = {
        didTimeout: false,
        timeRemaining: () => Math.max(0, 50 - (Date.now() - start))
      };
      if (processor(deadline)) {
        scheduleProcessing(processor, options);
      }
    }, 1);
  }
}
```
- **method 2: `requestAnimationFrame`  ✅** 

from practice side, the performance difference can be neglected, ('requestIdleCallback' ) is averagely 1-2ms total time faster, but I still go for  `requestAnimationFrame`, reasons are: 
- More consistent execution
- predictable timing (can guarantee the trademarks loaded as quick and consistent  as possible)
- More Browser Support
- requestAnimationFrame    // 98%+ browser support 
- requestIdleCallback     // ~80% browser support

**3.  Replace the `\w+` ✅**

`const REFERENCE_TOKENS = /(✓ᐩ|✓\s+ᐩ|✓|ᐩ|✕|ⓘ|\*+|[†‡¤∞§]|\(\d+\)|[A-Za-z0-9]+[®™℠])/`

- More Efficient Matching, no need to match the word.
- Reorder the characters. Special characters first (✓ᐩ|✓\s+ᐩ|✓|ᐩ|✕|ⓘ)

**4.  Traverse node  ✅ or touch innerHTML ?**
    1. From practice in my case, touch innerHTML is slower, and sometimes mistakenly handle the html structure don’t know why.
```
        .filter((el) => REFERENCE_TOKENS.test(el.innerHTML))
        // 1. Serializes entire element content to HTML string
        // 2. Parses all HTML including nested elements
        // 3. Tests against entire HTML content including tags
```
        
 2. batching for traverse node?  ✅ 
        1. If using  `scheduleProcessing` , manages time slices, and handles batching using `requestIdleCallback()` no more additional batching needed.
        2. if using `requestAnimationFrame` , we add extra batching. The performance are mostly same for three run(6*slower CPU, 4G)  I eventually pick size 10 as a balance number.
            - 1. batch size 5:  5.3ms,4.8ms.8.7ms
            - 2. batch size 10 : 9.8ms,6.4ms 5.7ms. ✅ 
            - 3. batch size 15: 7.7ms, 8.3ms, 9.5ms
  
**5.  Not overusing `createTreeWalker`✅**
        From practice, the `createTreeWalker` is even slower.
- The createTreeWalker way:
<img width="663" alt="Screenshot 2024-11-06 at 8 32 36 PM" src="https://github.com/user-attachments/assets/6adaec78-266d-4c9b-b673-aa5d7f8857c6">

- current solution
<img width="770" alt="Screenshot 2024-11-06 at 8 39 57 PM" src="https://github.com/user-attachments/assets/c0ec6ee6-d988-48ba-ac45-21057f8ea608">
